### PR TITLE
Fixes paths misbehaving on Windows by calling filepath.ToSlash()

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -21,6 +21,7 @@ func NewDomain(name string, path string) (*Domain, error) {
 		Languages: make(map[string]*Catalog),
 	}
 	for _, f := range files {
+		f := filepath.ToSlash(f)
 		fs := strings.Split(f, "/")
 		langCode := strings.ToLower(fs[len(fs)-3])
 		fd, err := os.Open(f)


### PR DESCRIPTION
The glob results return an OS-specific string, e.g. "locale\fi_FI\LC_MESSAGE\blah.po" which is unparseable by strings.Split(f, "/"). This translates all platform-specific slashes to actual slashes, so on Windows, it turns them into slashes from the original dashes.
