### PR TITLE
Pointer to the right godoc location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 Gettext implementation in Go
 ============================
 
-Documentation: http://go.pkgdoc.org/github.com/samuel/go-gettext/gettext
+Documentation: http://godoc.org/github.com/samuel/go-gettext/gettext


### PR DESCRIPTION
Got a redirect page on the original, fixed.
